### PR TITLE
Fix install instructions for casual-isearch-tmenu.

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ The following lines illustrate an installation of the Casual Suite with no custo
   (require 'casual-suite)
   (keymap-set calc-mode-map "C-o" #'casual-calc-tmenu)
   (keymap-set dired-mode-map "C-o" #'casual-dired-tmenu)
-  (keymap-set isearch-mode-map "<f2>" #'cc-isearch-menu-transient)
+  (keymap-set isearch-mode-map "C-o" #'casual-isearch-tmenu)
   (keymap-set ibuffer-mode-map "C-o" #'casual-ibuffer-tmenu)
   (keymap-set ibuffer-mode-map "F" #'casual-ibuffer-filter-tmenu)
   (keymap-set ibuffer-mode-map "s" #'casual-ibuffer-sortby-tmenu)
@@ -74,7 +74,7 @@ The following minimal configuration code using ~use-package~ for configuring eac
 
   (use-package casual-isearch
     :ensure nil
-    :bind (:map isearch-mode-map ("<f2>" . casual-isearch-tmenu)))
+    :bind (:map isearch-mode-map ("C-o" . casual-isearch-tmenu)))
 
   (use-package ibuffer
     :hook (ibuffer-mode . ibuffer-auto-mode)

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -46,7 +46,7 @@
 ;; (require 'casual-suite)
 ;; (keymap-set calc-mode-map "C-o" #'casual-calc-tmenu)
 ;; (keymap-set dired-mode-map "C-o" #'casual-dired-tmenu)
-;; (keymap-set isearch-mode-map "<f2>" #'cc-isearch-menu-transient)
+;; (keymap-set isearch-mode-map "C-o" #'casual-isearch-tmenu)
 ;; (keymap-set ibuffer-mode-map "C-o" #'casual-ibuffer-tmenu)
 ;; (keymap-set ibuffer-mode-map "F" #'casual-ibuffer-filter-tmenu)
 ;; (keymap-set ibuffer-mode-map "s" #'casual-ibuffer-sortby-tmenu)


### PR DESCRIPTION
Fix install instructions for `casual-isearch-tmenu`.