### PR TITLE
Merge development to main 20240930_222500

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ VERSION := $(shell ./scripts/read-version.sh $(MAIN_EL))
 # BUMP_LEVEL: major|minor|patch|prerelease|build
 BUMP_LEVEL=patch
 VERSION_BUMP := $(shell python -m semver bump $(BUMP_LEVEL) $(VERSION))
+VERSION_LAST_TAG := $(shell git tag --sort=-creatordate | head -n 1)
 
 .PHONY: tests					\
 create-pr					\
@@ -76,7 +77,7 @@ bump-casual:
 	sed -i 's/;; Version: $(VERSION)/;; Version: $(VERSION_BUMP)/' $(MAIN_EL)
 	sed -i 's/(defconst casual-suite-version "$(VERSION)"/(defconst casual-suite-version "$(VERSION_BUMP)"/' $(VERSION_EL)
 
-bump: checkout-development bump-casual
+bump: bump-casual
 	git commit -m 'Bump version to $(VERSION_BUMP)' $(MAIN_EL) $(VERSION_EL)
 	git push
 
@@ -122,7 +123,7 @@ create-release-tag: checkout-main bump
 
 create-gh-release: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
 create-gh-release: create-release-tag
-	gh release create -t v$(VERSION_BUMP) --notes-from-tag $(VERSION_BUMP)
+	gh release create -t v$(VERSION_BUMP) --generate-notes
 
 status:
 	git status

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -39,9 +39,14 @@ EMACS_ELPA_DIR=$(EMACS_CONFIG_DIR)/elpa
 PACKAGE_PATHS=-L $(AVY_DIR)				\
 -L $(EMACS_ELPA_DIR)/compat-30.0.0.0			\
 -L $(EMACS_ELPA_DIR)/seq-2.24				\
+-L $(EMACS_ELPA_DIR)/transpose-frame-current		\
 -L $(EMACS_ELPA_DIR)/transient-current			\
+-L $(EMACS_ELPA_DIR)/magit-current			\
+-L $(EMACS_ELPA_DIR)/magit-section-current		\
+-L $(EMACS_ELPA_DIR)/dash-current			\
+-L $(EMACS_ELPA_DIR)/with-editor-current		\
+-L $(EMACS_ELPA_DIR)/symbol-overlay-current		\
 -L $(CASUAL_LIB_LISP_DIR)				\
--L $(EMACS_ELPA_DIR)/symbol-overlay-20240311.1207	\
 -L $(CASUAL_BASE_DIR)/casual-calc/lisp			\
 -L $(CASUAL_BASE_DIR)/casual-avy/lisp			\
 -L $(CASUAL_BASE_DIR)/casual-info/lisp			\
@@ -51,7 +56,8 @@ PACKAGE_PATHS=-L $(AVY_DIR)				\
 -L $(CASUAL_BASE_DIR)/casual-bookmarks/lisp		\
 -L $(CASUAL_BASE_DIR)/casual-agenda/lisp		\
 -L $(CASUAL_BASE_DIR)/casual-isearch/lisp		\
--L $(CASUAL_BASE_DIR)/casual-symbol-overlay/lisp
+-L $(CASUAL_BASE_DIR)/casual-symbol-overlay/lisp	\
+-L $(CASUAL_BASE_DIR)/casual-editkit/lisp
 
 .PHONY: tests compile regression
 

--- a/lisp/casual-suite-version.el
+++ b/lisp/casual-suite-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-suite-version "1.7.2"
+(defconst casual-suite-version "1.7.3"
   "Casual Suite Version.")
 
 (defun casual-suite-version ()

--- a/lisp/casual-suite-version.el
+++ b/lisp/casual-suite-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-suite-version "1.7.2-rc.1"
+(defconst casual-suite-version "1.7.2"
   "Casual Suite Version.")
 
 (defun casual-suite-version ()

--- a/lisp/casual-suite-version.el
+++ b/lisp/casual-suite-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-suite-version "1.7.4-rc.1"
+(defconst casual-suite-version "1.7.4-rc.2"
   "Casual Suite Version.")
 
 (defun casual-suite-version ()

--- a/lisp/casual-suite-version.el
+++ b/lisp/casual-suite-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-suite-version "1.7.1"
+(defconst casual-suite-version "1.7.2-rc.1"
   "Casual Suite Version.")
 
 (defun casual-suite-version ()

--- a/lisp/casual-suite-version.el
+++ b/lisp/casual-suite-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-suite-version "1.7.3"
+(defconst casual-suite-version "1.7.4-rc.1"
   "Casual Suite Version.")
 
 (defun casual-suite-version ()

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-suite
 ;; Keywords: tools
-;; Version: 1.7.1
+;; Version: 1.7.2-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-calc "1.9.0") (casual-isearch "1.7.0") (casual-dired "1.4.0") (casual-ibuffer "1.0.1") (casual-avy "1.2.0") (casual-info "1.2.0") (casual-re-builder "1.0.2") (casual-bookmarks "1.0.0") (casual-agenda "1.0.1") (casual-symbol-overlay "1.0.1") (casual-editkit "1.0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-suite
 ;; Keywords: tools
-;; Version: 1.7.4-rc.1
+;; Version: 1.7.4-rc.2
 ;; Package-Requires: ((emacs "29.1") (casual-calc "1.9.0") (casual-isearch "1.7.0") (casual-dired "1.4.0") (casual-ibuffer "1.0.1") (casual-avy "1.2.0") (casual-info "1.2.0") (casual-re-builder "1.0.2") (casual-bookmarks "1.0.0") (casual-agenda "1.0.1") (casual-symbol-overlay "1.0.1") (casual-editkit "1.0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-suite
 ;; Keywords: tools
-;; Version: 1.7.2
+;; Version: 1.7.3
 ;; Package-Requires: ((emacs "29.1") (casual-calc "1.9.0") (casual-isearch "1.7.0") (casual-dired "1.4.0") (casual-ibuffer "1.0.1") (casual-avy "1.2.0") (casual-info "1.2.0") (casual-re-builder "1.0.2") (casual-bookmarks "1.0.0") (casual-agenda "1.0.1") (casual-symbol-overlay "1.0.1") (casual-editkit "1.0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-suite
 ;; Keywords: tools
-;; Version: 1.7.2-rc.1
+;; Version: 1.7.2
 ;; Package-Requires: ((emacs "29.1") (casual-calc "1.9.0") (casual-isearch "1.7.0") (casual-dired "1.4.0") (casual-ibuffer "1.0.1") (casual-avy "1.2.0") (casual-info "1.2.0") (casual-re-builder "1.0.2") (casual-bookmarks "1.0.0") (casual-agenda "1.0.1") (casual-symbol-overlay "1.0.1") (casual-editkit "1.0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-suite.el
+++ b/lisp/casual-suite.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-suite
 ;; Keywords: tools
-;; Version: 1.7.3
+;; Version: 1.7.4-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-calc "1.9.0") (casual-isearch "1.7.0") (casual-dired "1.4.0") (casual-ibuffer "1.0.1") (casual-avy "1.2.0") (casual-info "1.2.0") (casual-re-builder "1.0.2") (casual-bookmarks "1.0.0") (casual-agenda "1.0.1") (casual-symbol-overlay "1.0.1") (casual-editkit "1.0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 1.7.2**
  

- **Bump version to 1.7.3**
  

- **Bump version to 1.7.4-rc.1**
  

- **Sync `Version:` commit with release tag for package build**
  This changes the build process to sync the package `Version:` field commit
  with the release tag. This is to support use-package :vc in the upcoming Emacs
  30 release.
  

- **Bump version to 1.7.4-rc.2**
  

- **Update package paths for regression tests.**
  